### PR TITLE
docs(skills): trim verbosity and standardize agent paths

### DIFF
--- a/skills/custom/add-dotfiles-skill/SKILL.md
+++ b/skills/custom/add-dotfiles-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-dotfiles-skill
-description: Scaffold a new personal skill in this dotfiles repo (skills/custom/) and symlink it into Claude/Codex via npx skills. Use when the user wants to create, add, or author a custom or personal agent skill that should live in their dotfiles.
+description: Scaffold a new personal skill in this dotfiles repo (skills/custom/) and install it into Claude/Codex/pi via npx skills. Use when the user wants to create, add, or author a custom or personal agent skill that should live in their dotfiles.
 disable-model-invocation: true
 ---
 
@@ -9,18 +9,24 @@ disable-model-invocation: true
 ## Steps
 
 1. Ask for the skill's purpose and a short kebab-case `<name>` if not given.
-2. Draft it by invoking `skill-creator` and `writing-great-skills`
+2. Draft it by invoking `skill-creator` and `writing-great-skills`.
 3. Create `~/.dotfiles/skills/custom/<name>/SKILL.md` with YAML frontmatter
    (`name`, `description`) and the drafted body. Put any supporting files in the
    same directory.
-4. Add agents/openai.yaml
-4. When logic can be handled in a script to reduce token usage, look at the axi skill for principles.
-5. Symlink it into the agents:
+   - Add `disable-model-invocation: true` unless the skill should fire on its
+     own. Only a model-invocable skill's description is loaded into every
+     session; a disabled one costs nothing until the user types `/<name>`.
+4. Add `agents/openai.yaml`, with `allow_implicit_invocation` matching that
+   choice.
+5. When logic can move into a script to cut tokens, follow the `axi` skill.
+6. Install it:
 
        ~/.dotfiles/install/skills.sh
 
    (this runs `npx skills add ~/.dotfiles/skills/custom -g -s '*' -a
    claude-code codex pi antigravity-cli`).
-6. Confirm: `ls -la ~/.claude/skills/<name>` and `npx skills ls -g`.
+7. Confirm: `ls -la ~/.agents/skills/<name>` and `npx skills ls -g`.
 
-After editing `SKILL.md` re-run `~/.dotfiles/install/skills.sh` to resync.
+Install **copies** the source into `~/.agents/skills/<name>` and symlinks the
+per-agent directories at it — so after every edit to a `SKILL.md` or a script,
+re-run `~/.dotfiles/install/skills.sh` or you are testing the old copy.

--- a/skills/custom/branch/SKILL.md
+++ b/skills/custom/branch/SKILL.md
@@ -10,10 +10,9 @@ worth working on, and names the next step — one call, a handful of lines back.
 
 ## Run it
 
-    bash ~/.claude/skills/branch/branch.sh <name>
+    bash ~/.agents/skills/branch/branch.sh <name>
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit.
+Run through `bash` — skills install without the exec bit.
 
 **Always pass a name**, with the one exception noted under `--rebase`. The
 repository state decides what happens; the name is consumed only when a fresh
@@ -21,7 +20,7 @@ cut is actually needed. On a branch that already carries live work the script
 reports it and changes nothing, whatever name you passed — so passing one is
 always safe. Derive it in kebab-case from the work this session is about to do.
 
-Five flags narrow the job:
+Three flags carry more than `--help` says; `--help` lists all six:
 
 - `--status` — assess and report the plan, change nothing. Every refusal a run
   would raise comes back as a `plan:` line instead, so this always reports.
@@ -31,14 +30,11 @@ Five flags narrow the job:
   which fast-forwards the default on the way past.
 - `--new` — cut a fresh branch even when this one carries live work. It does
   not override the unpushed-commits refusal below.
-- `--push` — after landing, run the commit skill, which opens the pull request
-- `--base <branch>` — cut from this branch instead of the repository default
 
 ## Relay what it returns
 
-The output is the answer. Report the outcome line and the `next:` line. The
-script reads its result back from git after acting, so it already reflects
-reality — go straight to reporting it.
+Report the outcome line and the `next:` line as they come — the script re-reads
+git after acting, so its output is already reality.
 
 | Outcome | What happened |
 | --- | --- |

--- a/skills/custom/commit/SKILL.md
+++ b/skills/custom/commit/SKILL.md
@@ -11,25 +11,20 @@ handful of lines back.
 
 ## Run it
 
-    bash ~/.claude/skills/commit/commit.sh
+    bash ~/.agents/skills/commit/commit.sh
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit. Three flags narrow the job:
-
-- `--status` — report state only, commit nothing
-- `--dry-run` — preview the generated message, commit nothing
-- `--push` — after committing, run the pull request skill
+Run through `bash` — skills install without the exec bit. `--help` lists the
+flags.
 
 `--push` hands off to /pr rather than naming it as the next step, so one call
 commits and ships. A clean tree still hands off: on a branch that already
 carries commits, pushing means shipping what is there. Flags do not travel —
-`--draft` and `--keep` mean running /pr yourself.
+`--draft` and `--base` mean running /pr yourself.
 
 ## Relay what it returns
 
-The output is the answer. Report the `state`, the commit, and the `next` line.
-The script reads its result back from git after committing, so it already
-reflects reality — go straight to reporting it.
+Report the `state`, the commit, and the `next` line as they come — the script
+re-reads git after committing, so its output is already reality.
 
 Three states, three destinations:
 
@@ -45,13 +40,12 @@ A clean tree is a complete answer: say so and stop.
 
 Every error carries a `cause:` and a `help:` line — act on the `help:` line.
 
-An unapproved hook is the exception: it asks the user to run
-`wt config approvals add`, and that stays with the user. Approving a
-repository's hooks decides whether it may run arbitrary commands on their
-machine, so hand them the command and let them review it.
+`approval:` is the exception — hand the user `wt config approvals add`; never
+run it yourself.
 
 `fallback:` marks the cases where writing a Conventional Commits message
-yourself and running `git commit` is the reasonable recovery.
+yourself (no AI attribution) and running `git commit` is the reasonable
+recovery.
 
 ## Boundary
 

--- a/skills/custom/hunk/SKILL.md
+++ b/skills/custom/hunk/SKILL.md
@@ -13,10 +13,9 @@ call, a handful of lines back.
 
 ## Run it
 
-    bash ~/.claude/skills/hunk/hunk.sh $ARGUMENTS
+    bash ~/.agents/skills/hunk/hunk.sh $ARGUMENTS
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit.
+Run through `bash` — skills install without the exec bit.
 
 It picks the target from the repository's own state, so pass nothing else:
 
@@ -42,11 +41,9 @@ the user, since the viewer is theirs.
    command below.
 2. `hunk session review --repo . --json` for the file and hunk structure. Add
    `--include-patch` only for files whose diff text you actually need to read.
-3. Review against `~/.claude/CLAUDE.md` — root causes over symptoms, the
-   repository's existing conventions, the smallest coherent change.
-4. Batch every finding into one `hunk session comment apply --repo . --stdin`
+3. Batch every finding into one `hunk session comment apply --repo . --stdin`
    call, each anchored to the line it concerns.
-5. Report the count and the single most consequential finding.
+4. Report the count and the single most consequential finding.
 
 Comment where you carry information the user does not: a root cause, a broken
 invariant, a case the change misses. Silence on a hunk is a valid review.

--- a/skills/custom/mission/SKILL.md
+++ b/skills/custom/mission/SKILL.md
@@ -12,6 +12,10 @@ validation.
 
 ## Separate the roles
 
+Invoking this skill is the request to delegate: run workers and validators as
+subagents, each in a fresh context. You are the orchestrator — do not collapse
+the three roles into this one.
+
 - **Orchestrator:** Own the destination, validation contract, decomposition,
   shared state, scheduling, and completion decision. Do not implement features
   or perform their final validation.
@@ -132,7 +136,5 @@ Complete the mission only when every validation contract has independently
 produced its required evidence, all features are complete, and no in-scope
 blocker remains.
 
-If progress requires unavailable access, a user decision, unsafe boundary
-expansion, or an unresolvable dependency, halt and return the exact blocker,
-affected contract and feature IDs, attempts made, and the action needed from the
-user.
+On a genuine blocker, halt and return it exactly: the affected contract and
+feature IDs, the attempts made, and the action needed from the user.

--- a/skills/custom/pr/SKILL.md
+++ b/skills/custom/pr/SKILL.md
@@ -12,16 +12,10 @@ of it. `pr.sh --merge` lands the request and takes the worktree with it.
 
 ## Run it
 
-    bash ~/.claude/skills/pr/pr.sh
+    bash ~/.agents/skills/pr/pr.sh
 
-The scripts sit beside this file; run them through `bash`, since skills install
-without the executable bit. The flags that narrow the job:
-
-- `--status` / `--dry-run` — report the plan, change nothing
-- `--no-squash` / `--no-rebase` — leave the branch history alone
-- `--draft`, `--title <text>`, `--body <text>`, `--base <branch>`
-- `--no-watch` — skip the watch handoff
-- `--merge` — land an already-open request
+Run through `bash` — skills install without the exec bit. `--merge` lands an
+already-open request and has its own section below; `--help` lists the rest.
 
 Opening a request leaves the worktree standing. Nothing to `cd` to, nothing
 gone — the checkout stays until the request merges, because that is where a red
@@ -29,9 +23,8 @@ run gets investigated.
 
 ## Relay what it returns
 
-The output is the answer. Report the pipeline lines, the `pr:` URL, and the
-`next:` line. The script reads its result back from git and gh after acting, so
-it already reflects reality — go straight to reporting it.
+Report the pipeline lines, the `pr:` URL, and the `next:` line as they come —
+the script re-reads git and gh after acting, so its output is already reality.
 
 A branch carrying nothing the base lacks is a complete answer: say so and stop.
 
@@ -56,12 +49,13 @@ and exist for tighter loops; `--once` polls a single time and reports.
 The `checks:` line says which of four things happened.
 
 **`checks: pass`** — open the request: `gh pr view <url> --web`. Then offer to
-land it with `bash ~/.claude/skills/pr/pr.sh --merge` and wait for an answer.
+land it with `bash ~/.agents/skills/pr/pr.sh --merge` and wait for an answer.
 Review is the user's gate; do not walk through it for them.
 
-**`checks: fail`** — open the request the same way, then investigate. Launch one
-`general-purpose` agent with the failing check names from the `failed[...]`
-block and the `log:` path, and tell it to:
+**`checks: fail`** — open the request the same way, then investigate. Invoking
+this skill is the request for it: launch one `general-purpose` agent with the
+failing check names from the `failed[...]` block and the `log:` path, and tell
+it to:
 
 - read the log and the branch's diff against the base;
 - name the root cause of each failing check;
@@ -78,7 +72,7 @@ restarts the watch. Do not launch an agent; nothing has failed yet.
 
 ## Land it
 
-    bash ~/.claude/skills/pr/pr.sh --merge
+    bash ~/.agents/skills/pr/pr.sh --merge
 
 Squash-merges the open request, removes the worktree, deletes the branch local
 and remote, and fast-forwards the local default branch. This is the one path
@@ -101,19 +95,15 @@ behind. On a failed `--merge`, `removed:` says the same about the cleanup.
 
 Two cases stay with the user:
 
-- An unapproved hook asks them to run `wt config approvals add`. Approving a
-  repository's hooks decides whether it may run arbitrary commands on their
-  machine, so hand them the command and let them review it.
+- `approval:` — hand them `wt config approvals add`; never run it yourself.
 - The default branch is refused with two runnable options. Ask which they want
   rather than choosing.
 
 ## Boundary
 
-`wt merge` has no part in this. It fast-forwards the default branch, so the work
-would sit unmerged on local `main` until the pull request lands and every branch
-cut in the meantime would inherit it. The steps it bundles are run individually
-here instead, and `--merge` catches the default branch up only after GitHub has
-actually merged.
+`wt merge` has no part in this — it fast-forwards the default branch, so the
+work would sit unmerged on local `main` and every branch cut in the meantime
+would inherit it. `--merge` catches the default up only after GitHub has merged.
 
 Reviewing the request, re-running failed checks, and fixing what an
 investigation proposes are all separate asks.

--- a/skills/custom/setup-git-hooks/SKILL.md
+++ b/skills/custom/setup-git-hooks/SKILL.md
@@ -17,18 +17,10 @@ wording the README.
 
     bash ~/.agents/skills/setup-git-hooks/setup-git-hooks.sh
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit.
-
-| Mode | Writes | Job |
-| --- | --- | --- |
-| _(none)_ / `--plan` | nothing | Inspect and print the candidate table |
-| `--scan` | nothing | `--plan` plus a detection baseline and probe list |
-| `--apply --accept` | `prek.toml`, shims | Take the recommended set |
-| `--apply --pre-commit=a,b --pre-push=c` | `prek.toml`, shims | Take an exact selection |
-| `--apply … --extra=<file.json>` | `prek.toml`, shims | Merge hooks you found yourself |
-| `--heal` / `--heal --fix` | shims, managed config | Diagnose, then repair, an existing setup |
-| `--status` | nothing | What is configured and installed right now |
+Run through `bash` — skills install without the exec bit. No flags inspects and
+prints the candidate table; `--apply` writes `prek.toml` and the shims, `--heal`
+repairs an existing setup, `--scan` widens detection, `--status` reports. `--help`
+lists every flag.
 
 ## The main line
 
@@ -54,7 +46,7 @@ so pass the complete list for both stages. Naming no ids for a stage empties it.
 candidate table as recommended, so `--accept` takes it. With an explicit
 `--pre-commit=`/`--pre-push=` list you must name it there too — passing an extra
 you do not name is an error, not a silent drop. Its `stage` field says which list
-it belongs in. `setup-worktrunk` treats `--extra` the same way.
+it belongs in.
 
 **The placement rule:** correctness blocks the commit — formatters, linters,
 typecheck, hygiene, secrets. Running the code blocks the push — tests, build.
@@ -89,21 +81,8 @@ Then:
 1. Explore the repo yourself and find the checks it really runs.
 2. Write them to a JSON array of `{id, name, entry, stage, files, pass_filenames}`
    and apply with `--extra=<file.json>`.
-3. **Fold the gap back in.** For each hook you found that the script did not, ask
-   whether a file or naming rule would catch it in *any* repo:
-   - **Generalizes** — add a detector to `setup-git-hooks.sh` beside the
-     neighbouring ones, drop the marker from `UNKNOWN_MARKERS`, and prove it by
-     re-running plain `--plan`. It must find the hook with no scan.
-   - **Peculiar to this repo** — say so and change nothing.
-
-   Edit the source at `~/.dotfiles/skills/custom/setup-git-hooks/`, then re-run
-   `~/.dotfiles/install/skills.sh` before testing. The installed skill is a
-   **copy**, not a symlink, so an unsynced edit leaves you testing the old
-   script and reading the result as a failed detector.
-
-Propose the edit and get consent before making it: the script lives in the user's
-dotfiles. A scan spent this way is spent once — the next repo of that shape needs
-none.
+3. **Fold the gap back in** — teach the detectors what the scan found, following
+   `references/extending.md`.
 
 ## When it reports an error
 

--- a/skills/custom/setup-git-hooks/references/extending.md
+++ b/skills/custom/setup-git-hooks/references/extending.md
@@ -1,0 +1,19 @@
+# Folding a scan gap back into the detectors
+
+Read this after a `--scan` turned up a hook the script's own detection missed.
+
+For each hook you found that the script did not, ask whether a file or naming
+rule would catch it in *any* repo:
+
+- **Generalizes** — add a detector to `setup-git-hooks.sh` beside the
+  neighbouring ones, drop the marker from `UNKNOWN_MARKERS`, and prove it by
+  re-running plain `--plan`. It must find the hook with no scan.
+- **Peculiar to this repo** — say so and change nothing.
+
+The script lives in the user's dotfiles, so propose the edit and get consent
+before making it.
+
+Edit the source at `~/.dotfiles/skills/custom/setup-git-hooks/`, then re-run
+`~/.dotfiles/install/skills.sh` before testing. The installed skill is a
+**copy**, not a symlink — an unsynced edit leaves you testing the old script and
+reading the result as a failed detector.

--- a/skills/custom/setup-github/SKILL.md
+++ b/skills/custom/setup-github/SKILL.md
@@ -17,15 +17,9 @@ them the moment they land — `--apply` therefore refuses to imply a set.
 
     bash ~/.agents/skills/setup-github/setup-github.sh
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit.
-
-| Mode | Writes | Job |
-| --- | --- | --- |
-| _(none)_ / `--plan` | nothing | Probe and print the item table |
-| `--apply --accept` | GitHub settings | Take the recommended set |
-| `--apply --items=a,b` | GitHub settings | Take an exact selection |
-| `--status` | nothing | What is set right now |
+Run through `bash` — skills install without the exec bit. No flags probes and
+prints the item table; `--apply` converges; `--help` lists the modes, the flags
+and the item ids.
 
 `--repo=owner/name` acts on a repo you are not sitting in. `--force` adds the
 ruleset alongside a foreign one that already governs the default branch.
@@ -39,7 +33,7 @@ ruleset alongside a foreign one that already governs the default branch.
    of the ids, recommended ones first.
 3. **Apply.** `--apply --accept`, or `--apply --items=<ids>`.
 4. **Verify.** The script re-reads the repo and prints an `achieved[]` table.
-   Report it. Any row that did not reach its target is a failure to say plainly.
+   Report it; a row that did not reach its target is a failure.
 
 Done when step 4 has actually been run, not merely suggested. Nothing here needs
 committing — say so, rather than leaving the user looking for a diff.

--- a/skills/custom/setup-repo/SKILL.md
+++ b/skills/custom/setup-repo/SKILL.md
@@ -14,21 +14,20 @@ three calls that report one each. It only reads — two of the three areas need 
 user to choose from a table first, so converging stays with the individual
 skills.
 
-Those three carry `disable-model-invocation` (and `allow_implicit_invocation:
-false` for the OpenAI agents), so they cost nothing in a session that is not
-setting a repo up, and no agent fires one on its own. **That is why this skill
-drives them by reading their `SKILL.md` and following it, rather than invoking
-them as skills** — the read delivers exactly what a skill invocation would have,
-and it works the same in every agent. Only the user typing `/setup-git-hooks`
+Those three carry `disable-model-invocation`, so they cost nothing in a session
+that is not setting a repo up and no agent fires one on its own. **That is why
+this skill drives them by reading their `SKILL.md` and following it rather than
+invoking them as skills** — the read delivers what a skill invocation would
+have, and works the same in every agent. Only the user typing `/setup-git-hooks`
 reaches one directly.
 
 ## Run it
 
     bash ~/.agents/skills/setup-repo/setup-repo.sh
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit. It finds its siblings as sibling directories, so it
-works from the installed copy and from `~/.dotfiles/skills/custom/` alike.
+Run through `bash` — skills install without the exec bit. It finds its siblings
+as sibling directories, so it works from the installed copy and from
+`~/.dotfiles/skills/custom/` alike.
 
 | Area | Skill | Asks the user? |
 | --- | --- | --- |
@@ -73,35 +72,16 @@ finished too — say which, rather than leaving it looking unfinished.
 
 ## Reading the roll-up
 
-The `state` column decides what happens next:
-
-- **converged** / **configured** — done. Two words for one outcome: `converged`
-  is what the area that reconciles settings reports (github), `configured` what
-  the areas that write a config file report (git-hooks, worktrunk). Nothing to do
-  either way.
-- **pending** — the area has never been set up, or it is set up but still needs
-  something from the user. Follow the step in `next[]`.
-- **drifted** / **unmanaged** — a config exists but is wrong or belongs to
-  someone else. The skill's `--heal` names it; ask before repairing.
-- **skipped** — no GitHub remote. Nothing to do, and not a failure.
-- **blocked** — the sibling ran fine but cannot act: no admin on the GitHub repo.
-  Normal on a repo the user does not own. Only they can resolve it, by getting
-  admin or deciding to skip GitHub.
-- **error** — the sibling exited non-zero. The detail carries its `error:` line;
-  act on that, not on this table.
-- **unavailable** — that sibling skill is not installed. Re-run
-  `~/.dotfiles/install/skills.sh`.
-- **unknown** — the roll-up could not parse that sibling. Run the sibling
-  directly and trust its own output over this table.
-
-Only `converged`, `configured` and `skipped` count as done. Everything else adds
-to the pending tally and carries a `next[]` entry.
+The `state` column decides what happens next, and the run prints a `legend[]`
+for the states it actually produced — read the meanings there. Only `converged`,
+`configured` and `skipped` count as done; everything else adds to the pending
+tally and carries a `next[]` entry.
 
 A `next[]` entry naming a `SKILL.md` to read is a step that asks the user a
 question. A `next[]` entry that is a shell command does not.
 
 ## Boundary
 
-Sequencing the four areas is the whole job. What each area proposes, how it heals
+Sequencing the three areas is the whole job. What each area proposes, how it heals
 drift, and how it explains itself belong to that area's own skill — read those
 rather than second-guessing them from here.

--- a/skills/custom/setup-repo/setup-repo.sh
+++ b/skills/custom/setup-repo/setup-repo.sh
@@ -305,14 +305,43 @@ fi
 
 # --- report ----------------------------------------------------------------
 
+# The state column is only useful if its vocabulary travels with it, so the
+# report carries its own legend rather than leaving SKILL.md to hold a glossary
+# that drifts. Only the states this run produced are printed — a converged repo
+# should not pay to be told what `drifted` means.
+state_means() {
+	case "$1" in
+	converged) printf 'done — settings reconciled' ;;
+	configured) printf 'done — config file written' ;;
+	pending) printf 'never set up, or set up but still needs something from the user; follow next[]' ;;
+	drifted) printf 'a config exists but is wrong; the area skill --heal names it — ask before repairing' ;;
+	unmanaged) printf 'a config exists but belongs to someone else; --heal or --force, and the user chooses' ;;
+	skipped) printf 'no GitHub remote — nothing to do, and not a failure' ;;
+	blocked) printf 'the sibling ran but cannot act: no admin on the GitHub repo; only the user resolves it' ;;
+	error) printf 'the sibling exited non-zero — act on its own error: line, not this table' ;;
+	unavailable) printf 'that sibling skill is not installed — re-run install/skills.sh' ;;
+	unknown) printf 'could not parse that sibling — run it directly and trust its output over this table' ;;
+	*) return 1 ;;
+	esac
+}
+
 printf 'bin: %s\n' "${SELF/#$HOME/\~}"
 printf 'repo: %s\n' "$(basename "$REPO_ROOT")"
 
 rows=()
+legend=()
+seen=""
 pending_areas=0
 for rec in ${AREAS[@]+"${AREAS[@]}"}; do
 	IFS="$SEP" read -r area state detail <<<"$rec"
 	rows+=("  $area,$state,\"$detail\"")
+	case "$seen" in
+	*"|$state|"*) ;;
+	*)
+		seen="$seen|$state|"
+		if means=$(state_means "$state"); then legend+=("  $state,\"$means\""); fi
+		;;
+	esac
 	case "$state" in
 	converged | configured | skipped) ;;
 	*) pending_areas=$((pending_areas + 1)) ;;
@@ -320,6 +349,10 @@ for rec in ${AREAS[@]+"${AREAS[@]}"}; do
 done
 printf 'areas[%s]{area,state,detail}:\n' "${#rows[@]}"
 printf '%s\n' "${rows[@]}"
+if [ "${#legend[@]}" -gt 0 ]; then
+	printf 'legend[%s]{state,means}:\n' "${#legend[@]}"
+	printf '%s\n' "${legend[@]}"
+fi
 
 if [ "$pending_areas" -eq 0 ]; then
 	printf 'pending: 0 of %s areas — this repo is set up (no-op)\n' "${#rows[@]}"

--- a/skills/custom/setup-worktrunk/SKILL.md
+++ b/skills/custom/setup-worktrunk/SKILL.md
@@ -22,18 +22,10 @@ wording the README, and handing over the approval command.
 
     bash ~/.agents/skills/setup-worktrunk/setup-worktrunk.sh
 
-The script sits beside this file; run it through `bash`, since skills install
-without the executable bit.
-
-| Mode | Writes | Job |
-| --- | --- | --- |
-| _(none)_ / `--plan` | nothing | Inspect and print the pane and step tables |
-| `--scan` | nothing | `--plan` plus a probe list of where detection has looked |
-| `--apply --accept` | `.config/wt.toml` | Take the recommended set |
-| `--apply --panes=a,b --steps=c` | `.config/wt.toml` | Take an exact selection |
-| `--apply … --extra=<file.json>` | `.config/wt.toml` | Merge panes you found yourself |
-| `--heal` / `--heal --fix` | managed config | Diagnose, then repair, drift |
-| `--status` | nothing | What is configured right now |
+Run through `bash` — skills install without the exec bit. No flags inspects and
+prints the pane and step tables; `--apply` writes `.config/wt.toml`, `--heal`
+repairs drift, `--scan` widens detection, `--status` reports. `--help` lists
+every flag.
 
 ## The main line
 
@@ -56,7 +48,7 @@ the approvals command in hand — not merely been told one exists.
 **`--extra` offers panes; the selection still decides.** An extra joins the
 candidate table as recommended, so `--accept` takes it. With an explicit
 `--panes=` list you must name it there too — passing an extra you do not name is
-an error, not a silent drop. `setup-git-hooks` treats `--extra` the same way.
+an error, not a silent drop.
 
 **Apply is declarative.** It writes exactly the ids you name and drops the rest,
 so pass the complete list. Naming no panes is an error rather than an empty
@@ -96,20 +88,8 @@ Then:
 1. Explore the repo yourself and find the processes it really runs.
 2. Write them to a JSON array of `{id, dir, command}` and apply with
    `--extra=<file.json>`.
-3. **Fold the gap back in.** For each pane you found that the script did not, ask
-   whether a file or naming rule would catch it in *any* repo:
-   - **Generalizes** — add a branch to `detect_one_component` beside the
-     neighbouring ones, drop the marker from `UNKNOWN_MARKERS`, and prove it by
-     re-running plain `--plan`. It must find the pane with no scan.
-   - **Peculiar to this repo** — say so and change nothing.
-
-   Edit the source at `~/.dotfiles/skills/custom/setup-worktrunk/`, then re-run
-   `~/.dotfiles/install/skills.sh` before testing. The installed skill is a
-   **copy**, not a symlink, so an unsynced edit leaves you testing the old script
-   and reading the result as a failed detector.
-
-Propose the edit and get consent before making it: the script lives in the user's
-dotfiles.
+3. **Fold the gap back in** — teach the detectors what the scan found, following
+   `references/extending.md`.
 
 ## When it reports an error
 
@@ -121,9 +101,8 @@ Three are refusals rather than failures, and all three are correct:
   touched. Offer `--heal` or `--apply --force`, and let the user choose, since
   `--force` discards their config.
 - **unknown pane id** — the valid ids are printed with it.
-- **`approval:` on any run.** The script never approves hooks itself. Approving
-  decides whether this repo may run arbitrary commands on the user's machine, so
-  hand them `wt config approvals add` and let them review it.
+- **`approval:` on any run.** The script never approves hooks itself — hand the
+  user `wt config approvals add`; never run it yourself.
 
 ## Boundary
 

--- a/skills/custom/setup-worktrunk/references/extending.md
+++ b/skills/custom/setup-worktrunk/references/extending.md
@@ -1,0 +1,19 @@
+# Folding a scan gap back into the detectors
+
+Read this after a `--scan` turned up a pane the script's own detection missed.
+
+For each pane you found that the script did not, ask whether a file or naming
+rule would catch it in *any* repo:
+
+- **Generalizes** — add a branch to `detect_one_component` beside the
+  neighbouring ones, drop the marker from `UNKNOWN_MARKERS`, and prove it by
+  re-running plain `--plan`. It must find the pane with no scan.
+- **Peculiar to this repo** — say so and change nothing.
+
+The script lives in the user's dotfiles, so propose the edit and get consent
+before making it.
+
+Edit the source at `~/.dotfiles/skills/custom/setup-worktrunk/`, then re-run
+`~/.dotfiles/install/skills.sh` before testing. The installed skill is a
+**copy**, not a symlink — an unsynced edit leaves you testing the old script and
+reading the result as a failed detector.

--- a/skills/custom/shape/SKILL.md
+++ b/skills/custom/shape/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: shape
-description: Create clear, actionable contracts that define project goals, implementation details, and success validation criteria. Use this skill when you need to outline project objectives and ensure all key factors are addressed before moving forward with implementation.
+description: Turn a request into a compact contract — the observable destination, the implementation brief, and the validation contracts that prove it. Use before committing to implementation.
 disable-model-invocation: true
 ---
 
 # Shape
 
-Enter /plan mode and create a compact contract between intent, implementation, and validation.
+Create a compact contract between intent, implementation, and validation. Use
+EnterPlanMode when the shaped work will be implemented in this session; shaping
+an analysis or a decision needs no plan mode.
 
 ## 1. Make the destination clear
 
@@ -14,20 +16,14 @@ Name the observable destination first: what must become true and what lies
 outside this effort.
 
 - Inspect the relevant territory before prescribing the solution.
-- Resolve facts from available sources. Put consequential decisions to the
-  user, with a recommended answer.
 - Choose the cheapest method that reduces material uncertainty: inspection,
   research, comparison, prototype, or question.
 - When quality is difficult to describe, use reference artifacts and name the properties that should transfer.
 - Reframe the work when evidence invalidates the original premise.
 
-When useful, distinguish:
-
-- **known knowns:** explicit outcomes, constraints, facts, and decisions;
-- **known unknowns:** recognized gaps that may change the work;
-- **unknown knowns:** tacit preferences or criteria to surface as hypotheses;
-  and
-- **unknown unknowns:** relevant blind spots outside the current framing.
+Surface tacit criteria as explicit hypotheses, and name the blind spots outside
+the current framing — those are the gaps that reshape the work, not the ones
+already on the list.
 
 Ask together only decisions whose prerequisites are settled. Leave dependent
 questions as fog until earlier answers make them precise. Stop exploring when

--- a/skills/custom/tdd/SKILL.md
+++ b/skills/custom/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Implement or change software through a focused test-driven loop. Use when user or agent explicitly uses 'tdd' or invoked for behavior with an appropriate automated test seam, including a shape-work validation contract or mission worker feature.
+description: Implement or change software through a focused test-driven loop. Use when user or agent explicitly uses 'tdd' or invoked for behavior with an appropriate automated test seam, including a shape validation contract or mission worker feature.
 ---
 
 # TDD
@@ -10,7 +10,7 @@ for the next one.
 
 ## Establish the boundary
 
-Read the request, relevant `shape-work` validation contracts or mission feature,
+Read the request, relevant `shape` validation contracts or mission feature,
 repository instructions, current behavior, and nearby tests.
 
 - Treat validation contracts as the required outcome. Do not rewrite them into
@@ -38,11 +38,9 @@ Keep the list behavioral; defer implementation design. Do not turn the whole
 list into test code upfront. Select the next scenario that yields useful
 behavior or design information with the least setup.
 
-Scale the list to risk rather than coverage targets. Add generative or fuzz
-tests when correctness is better expressed as an invariant over a large,
-hostile, or combinatorial input space. Run fuzzing only in a disposable,
-bounded environment; retain the seed and reduce any failure to a deterministic
-regression case.
+Scale the list to risk rather than coverage targets. Where correctness is an
+invariant over a large or hostile input space, add bounded generative tests and
+reduce any failure to a deterministic regression case.
 
 ## Evolve one example at a time
 
@@ -65,13 +63,9 @@ the executable explanation of behavior.
 
 ## Hand off
 
-Return:
-
-- scenarios completed, deferred, or discovered, with contract mappings;
-- tests and production behavior changed;
-- the failing and passing commands and what each demonstrated;
-- consequential design feedback or deviations; and
-- remaining gaps or unsuitable seams.
+Beyond the usual report of what changed and what was verified: map the scenarios
+completed, deferred, and discovered to contract IDs, and name the design
+feedback the tests produced — friction, deviations, seams that were not honest.
 
 In a mission, report which contracts the work contributes to but do not mark
 them passed. Worker tests guide implementation; fresh validators still produce


### PR DESCRIPTION
Update install path references from `~/.claude/skills` to
`~/.agents/skills` across custom skills to reflect the copy-based
install model. Condense flag documentation into `--help` pointers,
extract repeated "fold the gap back in" detector-extension guidance
into shared `references/extending.md` files, and generalize the
`approval:` handoff wording consistently. Add a state legend to
`setup-repo.sh`'s report output so the roll-up is self-documenting.
